### PR TITLE
Fix bug

### DIFF
--- a/api/src/teams/requests/requests.service.ts
+++ b/api/src/teams/requests/requests.service.ts
@@ -104,7 +104,7 @@ export class TeamMembershipRequestsService {
     await this.teamMembershipRequestRepository.flush();
 
     if (state === MembershipRequestState.Approved) {
-      const teamMember = new TeamMember({ team: request.team, user, role: TeamRole.Member });
+      const teamMember = new TeamMember({ team: request.team, user: request.user, role: TeamRole.Member });
       await this.teamMemberRepository.persistAndFlush(teamMember);
     }
 


### PR DESCRIPTION
Le bug était que le member qui était ajouté dans l'association était la personne ayant approuvé la requête, il se retrouvait donc en double et la personne ayant fait la demande ne pouvait pas être acceptée